### PR TITLE
Ci test fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "gulp test",
     "postinstall": "bower install",
     "upload": "gulp upload"
   },


### PR DESCRIPTION
- [x] aws.json がなくても gulp test を実行できるようにする。
- [x] npm test で gulp test を実行する。 (b8dc3f4)