### PR TITLE
Readme windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
              ]
              easy_xml.WriteXmlIfChanged(content, self.project_path,
         -                               encoding="Windows-1252")
-        +                               encoding="shift_jis")
+        +                               encoding="ms932")
         diff -u "C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\easy_xml.py~" "C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\easy_xml.py"
         --- C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\easy_xml.py~	2015-12-29 12:28:39.797529200 +0900
         +++ C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\easy_xml.py	2015-12-29 12:28:43.738387400 +0900

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 
 1.  Install Node.js (4.2 or later, recommend 5.3 or later)
 
+1.  Install Java Runtime
+
 1.  Install & Run [npm-windows-upgrade](https://www.npmjs.com/package/npm-windows-upgrade)
 
     1.  Launch Command Prompt


### PR DESCRIPTION
Protractor 動かすときは Selenium のために Java Runtime のインストールが必要でした。

あと、 node-gyp でのエンコーディングの指定方法の改善。