### PR TITLE
Simplified like service

### DIFF
--- a/src/app/components/like/like.service.js
+++ b/src/app/components/like/like.service.js
@@ -6,17 +6,10 @@
     .factory('Like', Like);
 
   /** @ngInject */
-  function Like($q, $http, apiServer) {
+  function Like($http, apiServer) {
     return {
       post: function(id, user){
-        return $q(function(resolve, reject) {
-          $http.post(apiServer + '/production/location/' + id + '/like', angular.toJson({user: user}))
-          .then(function() {
-            resolve();
-          },function() {
-            reject(new Error('Failed to load markers.'));
-          });
-        });
+        return $http.post(apiServer + '/production/location/' + id + '/like', angular.toJson({user: user}));
       }
     };
   }

--- a/src/app/components/like/like.service.spec.js
+++ b/src/app/components/like/like.service.spec.js
@@ -1,0 +1,27 @@
+(function() {
+  'use strict';
+
+  describe('Like', function() {
+    var Like;
+    var $http;
+
+    beforeEach(module('kuro-hanpen'));
+
+    beforeEach(inject(function(_$q_, _$rootScope_, _$http_, _Like_) {
+      Like = _Like_;
+      $http = _$http_;
+    }));
+
+    it("tracks that $http.post() was called", function() {
+      spyOn($http, 'post');
+
+      Like.post('dummyId', 'dummmyUser');
+
+      expect($http.post)
+        .toHaveBeenCalledWith(
+          'https://m4fgyamv41.execute-api.ap-northeast-1.amazonaws.com/production/location/dummyId/like',
+          '{"user":"dummmyUser"}'
+        );
+    });
+  });
+})();


### PR DESCRIPTION
-   `Like` サービスで `$http` 使っているところは `$http` 自体が `$q` を返すので、そのまま返却。
-   `Like` サービスのユニットテストを追加。