### PR TITLE
漢字タイポス415 Std フォントを適用

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -18,7 +18,7 @@
 */
 
 body {
-  font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", Verdana, Arial, sans-serif;
+  font-family: "kan415typos-std", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", Verdana, Arial, sans-serif!important;
 }
 
 .angular-google-map-container {

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -17,10 +17,6 @@
 }
 */
 
-body {
-  font-family: "kan415typos-std", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", Verdana, Arial, sans-serif!important;
-}
-
 .angular-google-map-container {
   height: 100vh;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -41,5 +41,14 @@
     <!-- angular templates will be automatically converted in js and inserted here -->
     <!-- endinject -->
     <!-- endbuild -->
+    <script src="https://use.typekit.net/tde5evp.js"></script>
+    <script>
+      try {
+        Typekit.load({
+          async: true
+        });
+      } catch (e) {}
+    </script>
   </body>
+
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
     <!-- endinject -->
     <!-- endbuild -->
   </head>
-  <body>
+  <body class="tk-kan415typos-std">
     <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->


### PR DESCRIPTION
Adobe TypeKit のフォントを当ててみました。

-   [ヒヤコロシェア で使用されている書体](https://typekit.com/colophons/tde5evp)

一応、私個人のアカウントでライセンスを得てます。極端にアクセスが殺到しない限りは大丈夫なはず。